### PR TITLE
Improve wildcard support

### DIFF
--- a/task/Export-NUnitXml.ps1
+++ b/task/Export-NUnitXml.ps1
@@ -63,8 +63,8 @@ Function Export-NUnitXml {
             Default { $TestResult = 'Failure'; $TestSuccess = 'False' }
         }
 
-
-        $fileName = Split-Path $testFile  -leaf
+        $directoryName = Split-Path (Split-Path $testFile -Parent) -Leaf
+        $fileName = Split-Path $testFile -Leaf
 
         # generate body of XML
         $Header = @"
@@ -83,7 +83,7 @@ Function Export-NUnitXml {
 "@
 
         $testHeader = @"
-    <test-suite type="TestFixture" name="$fileName" executed="True" result="$TestResult" success="$TestSuccess" time="0.0" asserts="0" description="ARMTTK tests for $fileName">
+    <test-suite type="TestFixture" name="$directoryName\$fileName" executed="True" result="$TestResult" success="$TestSuccess" time="0.0" asserts="0" description="ARMTTK tests for $fileName">
     <results>`n
 "@
 
@@ -95,7 +95,7 @@ Function Export-NUnitXml {
 
             if ($result.Passed) {
                 $TestCase = @"
-    <test-case description="$($result.name) in template file $fileName" name="$($result.name) - $fileName" time="$($result.timespan.toString())" asserts="0" success="True" result="Success" executed="True">
+    <test-case description="$($result.name) in template file $directoryName\$fileName" name="$($result.name) - $fileName" time="$($result.timespan.toString())" asserts="0" success="True" result="Success" executed="True">
     </test-case>`n
 "@
             }
@@ -131,12 +131,7 @@ Function Export-NUnitXml {
             Throw "There was an problem when attempting to cast the output to XML : $($_.Exception.Message)"
         }
 
-        $NunitXml | Out-File -FilePath "$Path\$($(get-item $testFile).basename)-armttk.xml" -Encoding utf8 -Force
-
+        $hash = Get-FileHash -Path $testFile -Algorithm MD5
+        $NunitXml | Out-File -FilePath "$Path\$($(get-item $testFile).basename)-$($hash.Hash)-armttk.xml" -Encoding utf8 -Force
     }
-
-
-
-
 }
-

--- a/task/powershell.ps1
+++ b/task/powershell.ps1
@@ -1,9 +1,8 @@
 [CmdletBinding()] 
 param() 
  
-$ScriptDir = Split-Path -parent $MyInvocation.MyCommand.Path
-Import-Module "$ScriptDir\arm-ttk\arm-ttk.psd1"
-Import-Module "$ScriptDir\Export-NUnitXml.ps1"
+Import-Module "$PSScriptRoot\arm-ttk\arm-ttk.psd1"
+Import-Module "$PSScriptRoot\Export-NUnitXml.ps1"
 
 $templatelocation = get-VstsInput -Name templatelocation -Require
 $resultlocation = get-VstsInput -Name resultLocation -Require

--- a/task/powershell.ps1
+++ b/task/powershell.ps1
@@ -36,7 +36,7 @@ if ($item -is [System.IO.DirectoryInfo]){
     $templatelocation = "$($templatelocation.Trimend('\'))\*"
 }
 
-$files = Get-ChildItem $templatelocation -File -Filter "*.json"
+$files = Get-ChildItem $templatelocation -File -Filter "*.json" -Recurse
 $totalFileCount = $files.count
 
 if ($totalFileCount -lt 1) {

--- a/task/powershell.ps1
+++ b/task/powershell.ps1
@@ -15,7 +15,7 @@ function Test-FolderContents {
     )
     
     #Path is always set to folder due to limitation of ARMTTK, filter then picks file(s) or full folder to test
-    $results=Test-AzTemplate -TemplatePath "$folder" -File "$filter" -ErrorAction Continue
+    $results = Test-AzTemplate -TemplatePath $folder -File $filter -ErrorAction Continue
     Export-NUnitXml -TestResults $results -Path $resultlocation
 
     if (!$results) { 
@@ -37,11 +37,11 @@ if ($item -is [System.IO.DirectoryInfo]){
     $templatelocation = "$($templatelocation.Trimend('\'))\*"
 }
 
-$files = Get-ChildItem $templatelocation
+$files = Get-ChildItem $templatelocation -File -Filter "*.json"
 $totalFileCount = $files.count
 
 if ($totalFileCount -lt 1) {
-    Write-Error "No files found in provided path"
+    Write-Error "No json files found in provided path"
 }
 
 $FailedNumber = 0


### PR DESCRIPTION
This PR is referring to #4 
Handling wildcards is done inside the extension. This adds more power to the extension and leaves the toolkit to only handle literal paths.

This does open the possibility to have multiple templates with the same name, living in different directories. To handle this, I included the file hash of the template file in the test results file name. (While not breaking the convention to end the file with `-armttk.xml`.) 
And to better relate the test results to the tested template, I added the directory name to the test results.

I'm looking forward to comments and feedback.  