### PR TITLE
Create results directory if not exists

### DIFF
--- a/task/Export-NUnitXml.psm1
+++ b/task/Export-NUnitXml.psm1
@@ -19,7 +19,9 @@ Function Export-NUnitXml {
     )
 
     #Validate
-
+    if(-not (Test-Path $Path)){
+        New-Item -ItemType Directory -Force -Path $path | Out-Null
+    }
     if((Get-Item $Path) -isnot [System.IO.DirectoryInfo]){
         throw "resultLocation must be a folder, not a file"
     }


### PR DESCRIPTION
Hi Sam,
I have a minor usability improvement.
On the export module, there is a validation whether the result location indeed is a directory. This is implemented with `Get-Item`.
But if the location does not exist yet, that will throw:
`[error]Cannot find path 'D:\a\1\a\results' because it does not exist.`

I worked around this in our pipelines, by adding a separate task to create the location first.
However, I think it is nicer to include this in the atm-ttk-extension.

To do so, I added a check to verify if the location exists and if not, to create it.
It is slightly rough, because if you specify "results.xml" as a location, it will create a directory "results.xml". But I don't expect it to do harm, since the location does not exist yet.

Keep up the good work!

Regards,

Jacco