### PR TITLE
Add option to ignore exit code

### DIFF
--- a/task/invoke-ttk.psm1
+++ b/task/invoke-ttk.psm1
@@ -7,7 +7,7 @@ function Test-FolderContents {
         [string[]]$Test,
         [string[]]$Skip,
         [boolean]$mainTemplate,
-        [boolean]$ignoreExitCode
+        [boolean]$ignoreExitCode = $false
     )
     
     #Path is always set to folder due to limitation of ARMTTK, filter then picks file(s) or full folder to test

--- a/task/invoke-ttk.psm1
+++ b/task/invoke-ttk.psm1
@@ -7,6 +7,7 @@ function Test-FolderContents {
         [string[]]$Test,
         [string[]]$Skip,
         [boolean]$mainTemplate
+        [boolean]$ignoreExitCode
     )
     
     #Path is always set to folder due to limitation of ARMTTK, filter then picks file(s) or full folder to test
@@ -114,8 +115,16 @@ Function Invoke-TTK {
         }
     }
 
-    if ($FailedNumber -gt 0) {
-        throw "Failures found in test results"
+    if ($FailedNumber -gt 0  {
+        if($ignoreExitCode){
+            write-host "Failures found in test results but ignoring exit code"
+        }
+        else {
+            throw "Failures found in test results"
+        }
+        
+        
     }
-
+    
+    
 }

--- a/task/invoke-ttk.psm1
+++ b/task/invoke-ttk.psm1
@@ -53,7 +53,7 @@ Function Invoke-TTK {
         # treat all templates as main template
         [boolean]$allTemplatesAreMain = $false,
         # Whether to provide summary outputs at the CLI
-        [boolean]$cliOutputResults = $false
+        [boolean]$cliOutputResults = $false,
         # Whether to ignore exit code and always pass task
         [boolean]$ignoreExitCode = $false
 

--- a/task/invoke-ttk.psm1
+++ b/task/invoke-ttk.psm1
@@ -6,8 +6,7 @@ function Test-FolderContents {
         [boolean]$createResultsFiles,
         [string[]]$Test,
         [string[]]$Skip,
-        [boolean]$mainTemplate,
-        [boolean]$ignoreExitCode = $false
+        [boolean]$mainTemplate
     )
     
     #Path is always set to folder due to limitation of ARMTTK, filter then picks file(s) or full folder to test
@@ -55,6 +54,8 @@ Function Invoke-TTK {
         [boolean]$allTemplatesAreMain = $false,
         # Whether to provide summary outputs at the CLI
         [boolean]$cliOutputResults = $false
+        # Whether to ignore exit code and always pass task
+        [boolean]$ignoreExitCode = $false
 
     )
 

--- a/task/invoke-ttk.psm1
+++ b/task/invoke-ttk.psm1
@@ -6,7 +6,7 @@ function Test-FolderContents {
         [boolean]$createResultsFiles,
         [string[]]$Test,
         [string[]]$Skip,
-        [boolean]$mainTemplate
+        [boolean]$mainTemplate,
         [boolean]$ignoreExitCode
     )
     

--- a/task/invoke-ttk.psm1
+++ b/task/invoke-ttk.psm1
@@ -115,7 +115,7 @@ Function Invoke-TTK {
         }
     }
 
-    if ($FailedNumber -gt 0  {
+    if ($FailedNumber -gt 0)  {
         if($ignoreExitCode){
             write-host "Failures found in test results but ignoring exit code"
         }

--- a/task/powershell.ps1
+++ b/task/powershell.ps1
@@ -36,4 +36,4 @@ else{
 }
 
 
-Invoke-TTK -templatelocation $templatelocation  -resultlocation $resultlocation -Test $Test -Skip $Skip -mainTemplates $mainTemplates -allTemplatesAreMain $allTemplatesAreMain -cliOutputResults $cliOutputResults
+Invoke-TTK -templatelocation $templatelocation  -resultlocation $resultlocation -Test $Test -Skip $Skip -mainTemplates $mainTemplates -allTemplatesAreMain $allTemplatesAreMain -cliOutputResults $cliOutputResults -ignoreExitCode $ignoreExitCode

--- a/task/powershell.ps1
+++ b/task/powershell.ps1
@@ -12,7 +12,7 @@ $SkipString =    get-VstsInput -Name skipTests
 $mainTemplateString = get-VstsInput -Name mainTemplates
 [boolean]$allTemplatesAreMain = get-VstsInput -Name allTemplatesMain -AsBool
 [boolean]$cliOutputResults = get-VstsInput -Name cliOutputResults -AsBool
-
+[boolean]$ignoreExitCode = get-VstsInput -Name ignoreExitCode -AsBool
 
 if($TestString){
     $Test=$TestString.split(',').trim()

--- a/task/task.json
+++ b/task/task.json
@@ -11,7 +11,7 @@
     "version": {
       "Major": 1,
       "Minor": 2,
-      "Patch": 12
+      "Patch": 13
     },
     "instanceNameFormat": "Run Azure RM TTK Tests",
 
@@ -73,7 +73,7 @@
         "name": "ignoreExitCode",
         "type": "boolean",
         "label": "Do not fail task on failed tests",
-        "required": true,
+        "required": false,
         "helpMarkDown": "Ignore Exit Code and do not fail task when there are failed tests",
         "defaultValue": false
       }

--- a/task/task.json
+++ b/task/task.json
@@ -11,7 +11,7 @@
     "version": {
       "Major": 1,
       "Minor": 2,
-      "Patch": 14
+      "Patch": 15
     },
     "instanceNameFormat": "Run Azure RM TTK Tests",
 

--- a/task/task.json
+++ b/task/task.json
@@ -11,7 +11,7 @@
     "version": {
       "Major": 1,
       "Minor": 2,
-      "Patch": 9
+      "Patch": 10
     },
     "instanceNameFormat": "Run Azure RM TTK Tests",
 
@@ -68,7 +68,18 @@
         "required": false,
         "helpMarkDown": "Whether to provide summary results of tests in the Azure Devops Console",
         "defaultValue": false
+      },
+      {
+        "name": "ignoreExitCode",
+        "type": "boolean",
+        "label": "Do not fail task on failed tests",
+        "required": true,
+        "helpMarkDown": "Ignore Exit Code and do not fail task when there are failed tests",
+        "defaultValue": false
       }
+
+
+      
     ],
     "execution": {
       "PowerShell3": {

--- a/task/task.json
+++ b/task/task.json
@@ -11,7 +11,7 @@
     "version": {
       "Major": 1,
       "Minor": 2,
-      "Patch": 10
+      "Patch": 11
     },
     "instanceNameFormat": "Run Azure RM TTK Tests",
 

--- a/task/task.json
+++ b/task/task.json
@@ -11,7 +11,7 @@
     "version": {
       "Major": 1,
       "Minor": 2,
-      "Patch": 11
+      "Patch": 12
     },
     "instanceNameFormat": "Run Azure RM TTK Tests",
 

--- a/task/task.json
+++ b/task/task.json
@@ -11,7 +11,7 @@
     "version": {
       "Major": 1,
       "Minor": 2,
-      "Patch": 13
+      "Patch": 14
     },
     "instanceNameFormat": "Run Azure RM TTK Tests",
 


### PR DESCRIPTION
add the ignoreExitCode parameter which if set to true will not fail the task if tasks fail. Defaults to false (task fails if test fails).
Fixes #47 