### PR TITLE
Feature/recurse flag

### DIFF
--- a/Tests/invoke-ttk.Tests.ps1
+++ b/Tests/invoke-ttk.Tests.ps1
@@ -184,3 +184,24 @@ describe "bicep file tests"{
     }
 
 }
+
+describe "Recursing"{
+       BeforeAll{
+    $testPath = "TestDrive:\"
+    }
+
+
+    it "only runs test in top level folder"{
+        
+        Invoke-TTK -templatelocation "$here\testfiles\recurse"  -resultlocation $testPath -recurse $false
+        $(Get-ChildItem $testPath).count |  should -be 1
+      
+    }
+
+     it "runs all tests"{
+        
+        Invoke-TTK -templatelocation "$here\testfiles\recurse"  -resultlocation $testPath -recurse $true
+        $(Get-ChildItem $testPath).count |  should -be 2
+      
+    }
+}

--- a/Tests/testfiles/recurse/good-test-top.json
+++ b/Tests/testfiles/recurse/good-test-top.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "storageAccountName": {
+            "type": "String",
+            "defaultValue": "[uniqueString( resourceGroup().id, deployment().name )]"
+        },
+        "newOrExisting": {
+            "type": "String",
+            "allowedValues": [
+                "new",
+                "existing"
+            ]
+        }
+    },
+    "variables": {
+        "templatelink": "[concat('https://raw.githubusercontent.com/sam-cogan/Demos/master/NestedTemplates/',parameters('newOrExisting'),'StorageAccount.json')]"
+    },
+    "resources": [
+        {
+            "apiVersion": "2019-06-01",
+            "name": "nestedTemplate",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "incremental",
+                "templateLink": {
+                    "uri": "[variables('templatelink')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "StorageAccountName": {
+                        "value": "[parameters('storageAccountName')]"
+                    }
+                }
+            }
+        }
+    ],
+    "outputs": {
+        "exampleOutput": {
+            "value": "[reference('nestedTemplate')]",
+            "type": "object"
+        }
+    }
+}

--- a/Tests/testfiles/recurse/subfolder/good-test-sub.json
+++ b/Tests/testfiles/recurse/subfolder/good-test-sub.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "storageAccountName": {
+            "type": "String",
+            "defaultValue": "[uniqueString( resourceGroup().id, deployment().name )]"
+        },
+        "newOrExisting": {
+            "type": "String",
+            "allowedValues": [
+                "new",
+                "existing"
+            ]
+        }
+    },
+    "variables": {
+        "templatelink": "[concat('https://raw.githubusercontent.com/sam-cogan/Demos/master/NestedTemplates/',parameters('newOrExisting'),'StorageAccount.json')]"
+    },
+    "resources": [
+        {
+            "apiVersion": "2019-06-01",
+            "name": "nestedTemplate",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "incremental",
+                "templateLink": {
+                    "uri": "[variables('templatelink')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "StorageAccountName": {
+                        "value": "[parameters('storageAccountName')]"
+                    }
+                }
+            }
+        }
+    ],
+    "outputs": {
+        "exampleOutput": {
+            "value": "[reference('nestedTemplate')]",
+            "type": "object"
+        }
+    }
+}

--- a/task/invoke-ttk.psm1
+++ b/task/invoke-ttk.psm1
@@ -55,7 +55,10 @@ Function Invoke-TTK {
         # Whether to provide summary outputs at the CLI
         [boolean]$cliOutputResults = $false,
         # Whether to ignore exit code and always pass task
-        [boolean]$ignoreExitCode = $false
+        [boolean]$ignoreExitCode = $false,
+        # Whether to check all subfolders of template path for arm/bicep files
+        # Defaults to true to preserve backwards compatability
+        [boolean]$recurse = $true
 
     )
 
@@ -75,8 +78,12 @@ Function Invoke-TTK {
         $templatelocation = "$($templatelocation.Trimend('\'))\*"
     }
 
-
-    $bicepFiles = Get-ChildItem $templatelocation -include "*.bicep" -Recurse
+    if($recurse){
+        $bicepFiles = Get-ChildItem $templatelocation -include "*.bicep" -Recurse
+    }
+    else{
+        $bicepFiles = Get-ChildItem $templatelocation -include "*.bicep" 
+    }
 
     if($bicepFiles.count -gt 0){
         if ((Get-Command "bicep.exe" -ErrorAction SilentlyContinue) -eq $null -and (Get-Command "$PSScriptRoot\bicep.exe" -ErrorAction SilentlyContinue) -eq $null) {
@@ -88,7 +95,13 @@ Function Invoke-TTK {
         }
     }
 
-    $files = Get-ChildItem $templatelocation -include "*.json", "*.jsonc" -Recurse
+    if($recurse){
+        $files = Get-ChildItem $templatelocation -include "*.json", "*.jsonc" -Recurse
+    }
+    else{
+        $files = Get-ChildItem $templatelocation -include "*.json", "*.jsonc"
+    }
+
     $totalFileCount = $files.count
 
     if ($totalFileCount -lt 1) {

--- a/task/powershell.ps1
+++ b/task/powershell.ps1
@@ -13,6 +13,7 @@ $mainTemplateString = get-VstsInput -Name mainTemplates
 [boolean]$allTemplatesAreMain = get-VstsInput -Name allTemplatesMain -AsBool
 [boolean]$cliOutputResults = get-VstsInput -Name cliOutputResults -AsBool
 [boolean]$ignoreExitCode = get-VstsInput -Name ignoreExitCode -AsBool
+[boolean]$recurse = get-VstsInput -Name recurse -AsBool
 
 if($TestString){
     $Test=$TestString.split(',').trim()
@@ -36,4 +37,4 @@ else{
 }
 
 
-Invoke-TTK -templatelocation $templatelocation  -resultlocation $resultlocation -Test $Test -Skip $Skip -mainTemplates $mainTemplates -allTemplatesAreMain $allTemplatesAreMain -cliOutputResults $cliOutputResults -ignoreExitCode $ignoreExitCode
+Invoke-TTK -templatelocation $templatelocation  -resultlocation $resultlocation -Test $Test -Skip $Skip -mainTemplates $mainTemplates -allTemplatesAreMain $allTemplatesAreMain -cliOutputResults $cliOutputResults -ignoreExitCode $ignoreExitCode -recurse $recurse

--- a/task/task.json
+++ b/task/task.json
@@ -10,8 +10,8 @@
     "author": "Sam Cogan",
     "version": {
       "Major": 1,
-      "Minor": 4,
-      "Patch": 2
+      "Minor": 5,
+      "Patch": 1
     },
     "instanceNameFormat": "Run Azure RM TTK Tests",
 
@@ -23,6 +23,14 @@
         "helpMarkDown": "Folder containing templates, or individual template to test",
         "defaultValue": "$(System.DefaultWorkingDirectory)\\*"
       },
+      {
+        "name": "recurse",
+        "type": "boolean",
+        "label": "Recurse Template Location",
+        "required": false,
+        "helpMarkDown": "Recurse through all folders undeneath template location",
+        "defaultValue": true
+      }
       {
         "name": "resultLocation",
         "type": "string",

--- a/task/task.json
+++ b/task/task.json
@@ -30,7 +30,7 @@
         "required": false,
         "helpMarkDown": "Recurse through all folders undeneath template location",
         "defaultValue": true
-      }
+      },
       {
         "name": "resultLocation",
         "type": "string",


### PR DESCRIPTION
Adds a recurse flag to the extension to allow for not recursing through all subfolders.
The default value is set to true to preserve current functionality, set to false to stop recursion and only scan inside the specific folder.

Fixes #58 