### PR TITLE
Use guid instead of hash in generating output

### DIFF
--- a/task/Export-NUnitXml.psm1
+++ b/task/Export-NUnitXml.psm1
@@ -131,7 +131,7 @@ Function Export-NUnitXml {
             Throw "There was an problem when attempting to cast the output to XML : $($_.Exception.Message)"
         }
 
-        $hash = Get-FileHash -Path $testFile -Algorithm MD5
-        $NunitXml | Out-File -FilePath "$Path\$($(get-item $testFile).basename)-$($hash.Hash)-armttk.xml" -Encoding utf8 -Force
+        $guid = New-Guid
+        $NunitXml | Out-File -FilePath "$Path\$($(get-item $testFile).basename)-$($guid)-armttk.xml" -Encoding utf8 -Force
     }
 }


### PR DESCRIPTION
As described in https://github.com/sam-cogan/arm-ttk-extension/issues/64, here is a PR to change the hash to a guid in generating the output file. 
This makes sure the filename is unique and no FIPS issues 😉 

By the way, if the hash check is necessary feel free to remove this PR, this is just a small PR to see if I can help in any way.

Closes https://github.com/sam-cogan/arm-ttk-extension/issues/64